### PR TITLE
Add basic authentication client option

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,6 +80,14 @@ func WithErrorCallback(errorHandler func(err error)) clientOption {
 	}
 }
 
+func WithBasicAuth(username, password string) clientOption {
+	return func(c *promtailClient) {
+		if basicAuthExchanger, ok := c.exchanger.(BasicAuthExchanger); ok {
+			basicAuthExchanger.SetBasicAuth(username, password)
+		}
+	}
+}
+
 type clientOption func(c *promtailClient)
 
 type packedLogEntry struct {


### PR DESCRIPTION
I've added a new client Option `WithBasicAuth` which is getting passed a `username` and `password` to authenticate push API requests to loki with basic authentication.

Would be glad to hear from your opinion about these changes. :)